### PR TITLE
Implement graceful shutdown according to Next.js docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "postinstall": "next telemetry disable",
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "NEXT_MANUAL_SIG_HANDLE=true next start",
     "format": "prettier --write .",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,6 +1,17 @@
 import { Head, Html, Main, NextScript } from "next/document";
 import GlobalStyles from "../components/GlobalStyles";
 
+if (process.env.NEXT_MANUAL_SIG_HANDLE) {
+	process.on("SIGTERM", () => {
+		console.log("Received SIGTERM: ", "cleaning up");
+		process.exit(0);
+	});
+	process.on("SIGINT", () => {
+		console.log("Received SIGINT: ", "cleaning up");
+		process.exit(0);
+	});
+}
+
 export default function Document() {
 	return (
 		<Html lang="en">


### PR DESCRIPTION
To attempt to fix our restart issue on Render.com, I’m adding the graceful shutdown mechanism as suggested in the [Next.js docs](https://nextjs.org/docs/app/building-your-application/deploying#manual-graceful-shutdowns) and [this related discussion](https://github.com/vercel/next.js/discussions/19693).