### PR TITLE
Add keepAliveTimeout to next server

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "postinstall": "next telemetry disable",
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "next start --keepAliveTimeout 950000",
     "format": "prettier --write .",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Another attempt to fix our Render deployment, this time with the [keepAliveTimeout flag](https://nextjs.org/docs/pages/api-reference/next-cli#keep-alive-timeout).