### PR TITLE
Explicitly set the production server port to 10000

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "postinstall": "next telemetry disable",
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 10000",
     "format": "prettier --write .",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
This specifies a server port `10000` for the Next.js production server ([docs](https://nextjs.org/docs/pages/api-reference/next-cli#production)) to fix the deplyoment on Render. This is what their support person wrote:

> We've noticed recent releases of Next.js are exposing multiple ports, which can cause an issue.
>
> A workaround here would be to explicitly set a PORT environment variable on your service to 10000, which will stop the port detector from selecting an incorrect port.