### PR TITLE
Adjust border-radius value and apply it to more components

### DIFF
--- a/src/common/styleVariables.ts
+++ b/src/common/styleVariables.ts
@@ -56,7 +56,7 @@ export const borderWidths = {
 };
 
 export const borderRadiuses = {
-	big: 20,
+	medium: 10,
 };
 
 export const timings = {

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { ButtonHTMLAttributes } from "react";
-import { borderWidths, colors, fontWeights, lineHeights, timings } from "../../common/styleVariables";
+import { borderRadiuses, borderWidths, colors, fontWeights, lineHeights, timings } from "../../common/styleVariables";
 
 const StyledButton = styled.button({
 	appearance: "none",
@@ -10,7 +10,7 @@ const StyledButton = styled.button({
 	background: "transparent",
 	fontWeight: fontWeights.default,
 	border: `${borderWidths.default}px solid ${colors.blueDark}`,
-	borderRadius: "none",
+	borderRadius: borderRadiuses.medium,
 	transition: `all ${timings.short} ease-in-out`,
 	"&:hover": {
 		cursor: "pointer",

--- a/src/components/HomePage/RequestCreatorAndList/Block.tsx
+++ b/src/components/HomePage/RequestCreatorAndList/Block.tsx
@@ -10,7 +10,7 @@ const Block = styled.div<Props>(({ padding = spacings.get(5) }) => ({
 	color: colors.blueDark,
 	backgroundColor: colors.turquoise,
 	border: `${borderWidths.default}px solid ${colors.blueDark}`,
-	borderRadius: borderRadiuses.big,
+	borderRadius: borderRadiuses.medium,
 }));
 
 export default Block;

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { ReactNode } from "react";
 import { Tooltip as ReactTooltip } from "react-tooltip";
-import { colors } from "../../common/styleVariables";
+import { borderRadiuses, colors } from "../../common/styleVariables";
 
 const Element = styled.a({
 	color: colors.blueDark,
@@ -28,7 +28,7 @@ export default function Tooltip({ element = "span", children, tooltip, id }: Pro
 			<Element as={element} data-tooltip-id={id} aria-describedby={id}>
 				{children}
 			</Element>
-			<StyledTooltip id={id} offset={5} opacity={1.0}>
+			<StyledTooltip id={id} offset={5} opacity={1.0} style={{ borderRadius: borderRadiuses.medium }}>
 				{tooltip}
 			</StyledTooltip>
 		</>


### PR DESCRIPTION
**Source and related discussion:** https://www.figma.com/file/00NXZpsIADXqAHiRemXZHN?node-id=360:740&mode=design#516585240

The border-radius in Figma seems to be ~10px, which I’ve now applied across the board (Button, Tooltip, Event List components).

## Screenshot

![screenshot](https://github.com/technologiestiftung/kulturdaten-website/assets/6429568/6a936ce2-813a-4f29-9468-d273b439d635)
