### PR TITLE
SectionTitle: Adjust width logic to create 50/50 split

### DIFF
--- a/src/components/SectionTitle/index.tsx
+++ b/src/components/SectionTitle/index.tsx
@@ -14,6 +14,7 @@ const HeaderWrapper = styled.div(() => {
 
 const BannerBackdrop = styled.div<{ backgroundColor: BackgroundColor }>(({ backgroundColor }) => {
 	return {
+		flex: "1 1 50%",
 		position: "relative",
 		backgroundColor,
 		maxWidth: backgroundImageWidth,
@@ -59,7 +60,7 @@ const Label = styled.h2(() => ({
 const SectionImage = styled.div<{ headerImage: string }>(({ headerImage }) => {
 	return {
 		display: "none",
-		flex: "0 0 50%",
+		flex: "0 1 50%",
 		aspectRatio: "6 / 8",
 		backgroundImage: `url(${headerImage})`,
 		backgroundSize: "cover",


### PR DESCRIPTION
Small fix: We now have a proper 50/50 split of our SectionTitle areas (text and image block). (As discussed with @BugBoomBang via Huddle™.)

Fixes #26.

| Before | After |
| ------ | ----- |
| ![before](https://github.com/technologiestiftung/kulturdaten-website/assets/6429568/889009bc-4ed2-415f-bda0-3c5106d995e9) | ![after](https://github.com/technologiestiftung/kulturdaten-website/assets/6429568/3177128d-2fe6-4130-b676-ce7ed5ca4fce) |
