### PR TITLE
Make tooltip trigger element focusable with keyboard

### DIFF
--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { ReactNode } from "react";
-import { borderRadiuses, colors } from "../../common/styleVariables";
 import { ITooltip, Tooltip as ReactTooltip } from "react-tooltip";
+import { borderRadiuses, colors } from "../../common/styleVariables";
 
 const Element = styled.span({
 	color: colors.blueDark,
@@ -40,7 +40,7 @@ export default function Tooltip({
 }: Props) {
 	return (
 		<>
-			<Element as={element} data-tooltip-id={id} aria-describedby={id}>
+			<Element as={element} data-tooltip-id={id} aria-describedby={id} tabIndex={0}>
 				{children}
 			</Element>
 			<StyledTooltip


### PR DESCRIPTION
… otherwise, it’s impossible to trigger the tooltip without a mouse/pointer/touch event.

And in general, all interactive elements should be reachable via keyboard focus.