### PR TITLE
Update .env.example to include correct API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-API_BASE_URL=http://localhost:3000/api/v1
+API_BASE_URL=http://localhost:3000/api


### PR DESCRIPTION
We no longer use `/v1` as part of the backend base URL, so this PR updates the `.env.example` file to reflect that.