### PR TITLE
Fix API base URL configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-API_BASE_URL=http://localhost:3000/api
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000/api

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -5,7 +5,7 @@ import { OpenAPI } from "./client/core/OpenAPI";
  * Use this client for all API requests.
  */
 const apiClient = new APIClient({
-	BASE: process.env.API_BASE_URL || OpenAPI.BASE,
+	BASE: process.env.NEXT_PUBLIC_API_BASE_URL || OpenAPI.BASE,
 });
 
 export default apiClient;


### PR DESCRIPTION
Fixes the configuration of the API base url by using the proper `NEXT_PUBLIC_` prefix which makes the environment variable available in the client code (where the API requests are eventually being made).