### PR TITLE
Make fold corner work independently from viewport width

### DIFF
--- a/public/images/title-frame-blue-corner.svg
+++ b/public/images/title-frame-blue-corner.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 600 600" fill-rule="evenodd" stroke-miterlimit="9" xmlns:v="https://vecta.io/nano"><path d="M597.958 0v552.797h-34.256v45.134H0m564.231.915l34.256-45.134" fill="none" stroke="#1e3791" stroke-width="4.001"/></svg>

--- a/src/components/SectionTitle/FoldSvg.tsx
+++ b/src/components/SectionTitle/FoldSvg.tsx
@@ -1,0 +1,14 @@
+export default function FoldSvg() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="38"
+			height="49"
+			viewBox="0 0 38 49"
+			fillRule="evenodd"
+			strokeMiterlimit="9"
+		>
+			<path d="M38 1.797H1.702V49m.395-1.239L36.43 2.577" fill="none" stroke="#1e3791" strokeWidth="4" />
+		</svg>
+	);
+}

--- a/src/components/SectionTitle/index.tsx
+++ b/src/components/SectionTitle/index.tsx
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
 import { FC } from "react";
 import { colors, fontWeights, lineHeights, mediaQueries, spacings } from "../../common/styleVariables";
+import FoldSvg from "./FoldSvg";
 
 type BackgroundColor = string;
-const backgroundImageWidth = "600px";
 
 const HeaderWrapper = styled.div(() => {
 	return {
@@ -17,21 +17,15 @@ const BannerBackdrop = styled.div<{ backgroundColor: BackgroundColor }>(({ backg
 		flex: "1 1 50%",
 		position: "relative",
 		backgroundColor,
-		maxWidth: backgroundImageWidth,
 	};
 });
 
-const Fold = styled.div(() => {
-	const foldWidth = "36px";
-	const foldHeight = "46px";
-	return {
-		position: "absolute",
-		bottom: 0,
-		right: 0,
-		background: colors.grayLight,
-		width: foldWidth,
-		height: foldHeight,
-	};
+const Fold = styled.div({
+	width: "38px",
+	position: "absolute",
+	bottom: 0,
+	right: 0,
+	background: colors.grayLight,
 });
 
 const Title = styled.div(() => {
@@ -42,12 +36,7 @@ const Title = styled.div(() => {
 		alignItems: "center",
 		minHeight: "100%",
 		padding: `${spacings.get(10)}px ${spacings.get(5)}px`,
-		backgroundImage: `url("/images/title-frame-blue-corner.svg")`,
-		backgroundSize: backgroundImageWidth,
-		backgroundRepeat: "no-repeat",
-		backgroundPosition: "bottom right",
-		borderTop: `4px solid ${colors.blueDark}`,
-		borderLeft: `4px solid ${colors.blueDark}`,
+		border: `4px solid ${colors.blueDark}`,
 		color: colors.blueDark,
 		fontSize: `clamp(2.0rem, 8vw, 3.5rem)`,
 		fontWeight: fontWeights.medium,
@@ -82,8 +71,10 @@ const SectionTitle: FC<SectionTitleProps> = ({ label, headingLevel, backgroundCo
 	return (
 		<HeaderWrapper>
 			<BannerBackdrop backgroundColor={backgroundColor}>
-				<Fold />
 				<Title as={headingLevel}>{label}</Title>
+				<Fold>
+					<FoldSvg />
+				</Fold>
 			</BannerBackdrop>
 			<SectionImage headerImage={headerImage} />
 		</HeaderWrapper>


### PR DESCRIPTION
Fixes a UI bug by making our "fold" corner work independently of the borders and thus viewport widths/heights.

| Before | After |
| ------ | ----- |
| ![Screenshot 2023-08-22 at 16-59-33 Kulturdaten berlin website](https://github.com/technologiestiftung/kulturdaten-website/assets/6429568/3d00af8e-1868-4ab6-b679-81167fb76101) |    ![Screenshot 2023-08-22 at 16-59-42 Kulturdaten berlin website](https://github.com/technologiestiftung/kulturdaten-website/assets/6429568/722f3d70-b0cb-4afe-9f99-c592bdce77f2)   |