### PR TITLE
Add react-axe to our local development setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "use-debounce": "^9.0.4"
       },
       "devDependencies": {
+        "@axe-core/react": "4.7.3",
         "@storybook/addon-essentials": "7.2.1",
         "@storybook/addon-links": "7.2.1",
         "@storybook/addon-styling": "1.3.5",
@@ -113,6 +114,16 @@
       },
       "bin": {
         "x-default-browser": "bin/x-default-browser.js"
+      }
+    },
+    "node_modules/@axe-core/react": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.7.3.tgz",
+      "integrity": "sha512-dN2ZqUdaWJNmxEuedJKkAZBBQWs1qj/Aeby2x8ZKMhhcDBGkcT42MRlaOMWTvPG/YosP6RaGi160eFFZ3TiUMg==",
+      "dev": true,
+      "dependencies": {
+        "axe-core": "^4.7.0",
+        "requestidlecallback": "^0.3.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -21409,6 +21420,12 @@
         "strip-ansi": "^6.0.1"
       }
     },
+    "node_modules/requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
+      "dev": true
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -24375,6 +24392,16 @@
       "dev": true,
       "requires": {
         "default-browser-id": "3.0.0"
+      }
+    },
+    "@axe-core/react": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.7.3.tgz",
+      "integrity": "sha512-dN2ZqUdaWJNmxEuedJKkAZBBQWs1qj/Aeby2x8ZKMhhcDBGkcT42MRlaOMWTvPG/YosP6RaGi160eFFZ3TiUMg==",
+      "dev": true,
+      "requires": {
+        "axe-core": "^4.7.0",
+        "requestidlecallback": "^0.3.0"
       }
     },
     "@babel/code-frame": {
@@ -39784,6 +39811,12 @@
         "lodash": "^4.17.21",
         "strip-ansi": "^6.0.1"
       }
+    },
+    "requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "use-debounce": "^9.0.4"
   },
   "devDependencies": {
+    "@axe-core/react": "4.7.3",
     "@storybook/addon-essentials": "7.2.1",
     "@storybook/addon-links": "7.2.1",
     "@storybook/addon-styling": "1.3.5",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,8 +1,22 @@
 import { NextIntlClientProvider } from "next-intl";
 import type { AppProps } from "next/app";
+import React from "react";
+import ReactDOM from "react-dom";
 import "react-tooltip/dist/react-tooltip.css";
 import GlobalStyles from "../components/GlobalStyles";
 import { useAnalytics } from "../hooks/useAnalytics";
+
+/**
+ * Accessibility tool - outputs to devtools console on dev only and client-side only.
+ * @see https://github.com/dequelabs/axe-core-npm
+ */
+if (typeof window !== "undefined" && process.env.NODE_ENV !== "production") {
+	const loadAxe = async () => {
+		const axe = (await import("@axe-core/react")).default;
+		axe(React, ReactDOM, 1_000);
+	};
+	loadAxe();
+}
 
 type CustomPageProps = {
 	messages: IntlMessages;


### PR DESCRIPTION
Adds [react-axe](https://github.com/dequelabs/axe-core-npm/blob/develop/packages/react/README.md) (accessibility testing tool) to our setup (it will only run during local development).

So far, we seem to have no violations. 🎉
If we had any violations, we would get a console error like this (tested by removing the `aria-label` from our burger button):
![Bildschirmfoto 2023-08-24 um 16 40 20](https://github.com/technologiestiftung/kulturdaten-website/assets/6429568/57f57128-5c8c-4957-a222-7eda18c2cba9)
