### PR TITLE
refactor: use new backend filter to save one api request

### DIFF
--- a/src/api/kulturdaten.berlin.openapi.generated.yml
+++ b/src/api/kulturdaten.berlin.openapi.generated.yml
@@ -1427,18 +1427,7 @@ paths:
             schema:
               type: array
               default:
-                - "2"
-                - "4"
-                - "5"
-                - "6"
-                - "7"
-                - "8"
-                - "9"
-                - "10"
-                - "11"
-                - "12"
-                - "13"
-                - "25"
+                - "22"
               items:
                 type: string
       responses:
@@ -4349,9 +4338,26 @@ components:
     SearchEventsRequest:
       type: object
       properties:
+        matchMode:
+          type: string
+          enum:
+            - any
+            - all
         searchFilter:
           type: object
           additionalProperties: true
+        byAttractionTags:
+          type: object
+          properties:
+            tags:
+              type: array
+              items:
+                type: string
+            matchMode:
+              type: string
+              enum:
+                - any
+                - all
     SearchEventsResponse:
       type: object
       properties:

--- a/src/components/HomePage/RequestCreatorAndList/requests.ts
+++ b/src/components/HomePage/RequestCreatorAndList/requests.ts
@@ -11,9 +11,11 @@ export const REQUESTS: Request[] = [
 		i18nKey: "request-1-text",
 		loadData: async () =>
 			await loadEventsWithAttractions({
-				"attractions.referenceLabel.de": {
-					$regex: "exkursion",
-					$options: "i",
+				searchFilter: {
+					"attractions.referenceLabel.de": {
+						$regex: "exkursion",
+						$options: "i",
+					},
 				},
 			}),
 	},
@@ -28,20 +30,15 @@ export const REQUESTS: Request[] = [
 				},
 			});
 			const locations = locationsResponse.data?.locations || [];
-			const attractionsResponse = await apiClient.discoverCulturalData.postAttractionsSearch(1, 500, {
+			return await loadEventsWithAttractions({
+				matchMode: "all",
 				searchFilter: {
-					tags: {
-						$in: ["attraction.category.Exhibitions"],
+					"locations.referenceId": {
+						$in: locations.map((location) => location.identifier),
 					},
 				},
-			});
-			const attractions = attractionsResponse.data?.attractions || [];
-			return await loadEventsWithAttractions({
-				"attractions.referenceId": {
-					$in: attractions.map((attraction) => attraction.identifier),
-				},
-				"locations.referenceId": {
-					$in: locations.map((location) => location.identifier),
+				byAttractionTags: {
+					tags: ["attraction.category.Exhibitions"],
 				},
 			});
 		},
@@ -58,12 +55,14 @@ export const REQUESTS: Request[] = [
 			});
 			const attractions = attractionsResponse.data?.attractions || [];
 			return await loadEventsWithAttractions({
-				"attractions.referenceId": {
-					$in: attractions.map((attraction) => attraction.identifier),
-				},
-				"attractions.referenceLabel.de": {
-					$regex: "robot",
-					$options: "i",
+				searchFilter: {
+					"attractions.referenceId": {
+						$in: attractions.map((attraction) => attraction.identifier),
+					},
+					"attractions.referenceLabel.de": {
+						$regex: "robot",
+						$options: "i",
+					},
 				},
 			});
 		},
@@ -72,13 +71,15 @@ export const REQUESTS: Request[] = [
 		i18nKey: "request-4-text",
 		loadData: async () =>
 			await loadEventsWithAttractions({
-				"attractions.referenceLabel.de": {
-					$regex: "konzert",
-					$options: "i",
-				},
-				"admission.ticketType": {
-					$regex: "ticketType.freeOfCharge",
-					$options: "i",
+				searchFilter: {
+					"attractions.referenceLabel.de": {
+						$regex: "konzert",
+						$options: "i",
+					},
+					"admission.ticketType": {
+						$regex: "ticketType.freeOfCharge",
+						$options: "i",
+					},
 				},
 			}),
 	},

--- a/src/services/apiRequests.ts
+++ b/src/services/apiRequests.ts
@@ -34,9 +34,9 @@ function getDifferentEvents(events: Event[], amount: number) {
  * Loads all events with their matching (first) attraction and returns a nested list, sorted by the event start time.
  */
 export async function loadEventsWithAttractions(
-	searchFilter: SearchEventsRequest["searchFilter"]
+	searchEventsRequest: SearchEventsRequest
 ): Promise<EventWithAttraction[]> {
-	const eventsResponse = await apiClient.discoverCulturalData.postEventsSearch(1, 500, { searchFilter });
+	const eventsResponse = await apiClient.discoverCulturalData.postEventsSearch(1, 500, searchEventsRequest);
 	const events = eventsResponse.data?.events || [];
 	const fiveDifferentEvents = getDifferentEvents(events, 5);
 	const attractionIds = fiveDifferentEvents.map(getAttractionId).filter(Boolean);


### PR DESCRIPTION
Uses the new attraction tag filter coming from https://github.com/technologiestiftung/kulturdaten.berlin/pull/32/ to reduce two API requests to one.