### PR TITLE
chore: use node version from .nvmrc in GitHub workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
       - name: Install Dependencies
         run: npm install
       - name: Generate OpenAPI client

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
       - name: Install Dependencies
         run: npm install
       - name: Generate OpenAPI client


### PR DESCRIPTION
Does what the title says! Also improves the job name of our Linter workflow.

Reference: https://github.com/actions/setup-node